### PR TITLE
fix(users): return JWT on user creation

### DIFF
--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -5,6 +5,7 @@ const Bcrypt   = Bluebird.promisifyAll(require('bcrypt'));
 
 const Config = require('../../../../config');
 const Errors = require('../../../libraries/errors');
+const JWT    = require('../../../libraries/jwt');
 const User   = require('../../../models/user');
 
 exports.list = function () {
@@ -32,5 +33,5 @@ exports.create = function (payload) {
 
     return new User(payload).save();
   })
-  .then((user) => new User({ id: user.id }).fetch());
+  .then((user) => JWT.sign(user));
 };

--- a/test/plugins/features/users/controller.test.js
+++ b/test/plugins/features/users/controller.test.js
@@ -55,8 +55,8 @@ describe('user controller', () => {
 
     it('saves a user with a hashed password', () => {
       return Controller.create({ username: 'test', password: 'test' })
-      .then((user) => {
-        expect(user.get('password')).to.have.length(60);
+      .then((session) => {
+        expect(session.token).to.be.a('string');
       });
     });
 


### PR DESCRIPTION
Fixes robinjoseph08/pokedextracker.com#28

return a jwt instead of a user object so a user can be logged in immediately