### PR TITLE
fix(captures): speed up the list endpoint

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -14,7 +14,6 @@ const server = new Hapi.Server({
       stripTrailingSlash: true
     },
     routes: {
-      json: { space: 2 },
       cors: { credentials: true }
     }
   }


### PR DESCRIPTION
the way this was done before was super inefficient (taking up to ~1.2s in production). with these refactors (and removal of extra whitespace), it's brought it down to ~200ms which is much better

fixes robinjoseph08/pokedextracker.com#49