### PR TITLE
feat(captures): accept array of pokemon for creation and deletion

### DIFF
--- a/src/libraries/errors.js
+++ b/src/libraries/errors.js
@@ -2,7 +2,6 @@
 
 const CreateBoomError = require('create-boom-error').bind(exports);
 
-CreateBoomError('AlreadyExists', 422, (item) => `${item} already exists`);
 CreateBoomError('ExistingUsername', 422, 'username is already taken');
 CreateBoomError('InvalidPassword', 422, 'password is invalid');
 CreateBoomError('NotFound', 404, (item) => `${item} not found`);

--- a/src/plugins/features/captures/index.js
+++ b/src/plugins/features/captures/index.js
@@ -19,7 +19,7 @@ exports.register = (server, options, next) => {
     config: {
       auth: 'token',
       handler: (request, reply) => reply(Controller.create(request.payload, request.auth.credentials)),
-      validate: { payload: { pokemon: Joi.number().integer().required() } }
+      validate: { payload: { pokemon: Joi.array().items(Joi.number().integer()).single().required() } }
     }
   }, {
     method: 'DELETE',
@@ -27,7 +27,7 @@ exports.register = (server, options, next) => {
     config: {
       auth: 'token',
       handler: (request, reply) => reply(Controller.delete(request.payload, request.auth.credentials)),
-      validate: { payload: { pokemon: Joi.number().integer().required() } }
+      validate: { payload: { pokemon: Joi.array().items(Joi.number().integer()).single().required() } }
     }
   }]);
 

--- a/test/plugins/features/captures/controller.test.js
+++ b/test/plugins/features/captures/controller.test.js
@@ -54,25 +54,29 @@ describe('capture controller', () => {
   describe('create', () => {
 
     it('creates a capture', () => {
-      return Controller.create({ pokemon: secondPokemon.national_id }, { id: user.id })
-      .then((capture) => {
-        expect(capture.get('pokemon_id')).to.eql(secondPokemon.national_id);
-        expect(capture.get('user_id')).to.eql(user.id);
-        expect(capture.get('captured')).to.be.true;
+      return Controller.create({ pokemon: [secondPokemon.national_id] }, { id: user.id })
+      .then((captures) => {
+        expect(captures).to.have.length(1);
+        expect(captures.at(0).get('pokemon_id')).to.eql(secondPokemon.national_id);
+        expect(captures.at(0).get('user_id')).to.eql(user.id);
+        expect(captures.at(0).get('captured')).to.be.true;
       });
     });
 
     it('rejects with a bad pokemon id', () => {
-      return Controller.create({ pokemon: -1 }, { id: user.id })
+      return Controller.create({ pokemon: [-1] }, { id: user.id })
       .catch((err) => err) .then((err) => {
         expect(err).to.be.an.instanceof(Errors.NotFound);
       });
     });
 
-    it('rejects if the capture already exists', () => {
-      return Controller.create({ pokemon: firstPokemon.national_id }, { id: user.id })
-      .catch((err) => err) .then((err) => {
-        expect(err).to.be.an.instanceof(Errors.AlreadyExists);
+    it('does not err for duplicate captures', () => {
+      return Controller.create({ pokemon: [firstPokemon.national_id] }, { id: user.id })
+      .then((captures) => {
+        expect(captures).to.have.length(1);
+        expect(captures.at(0).get('pokemon_id')).to.eql(firstPokemon.national_id);
+        expect(captures.at(0).get('user_id')).to.eql(user.id);
+        expect(captures.at(0).get('captured')).to.be.true;
       });
     });
 
@@ -81,7 +85,7 @@ describe('capture controller', () => {
   describe('delete', () => {
 
     it('deletes a capture', () => {
-      return Controller.delete({ pokemon: firstPokemon.national_id }, { id: user.id })
+      return Controller.delete({ pokemon: [firstPokemon.national_id] }, { id: user.id })
       .then((res) => {
         expect(res.deleted).to.be.true;
 
@@ -89,13 +93,6 @@ describe('capture controller', () => {
       })
       .then((capture) => {
         expect(capture).to.be.null;
-      });
-    });
-
-    it('rejects with a bad pokemon id', () => {
-      return Controller.delete({ pokemon: -1 }, { id: user.id })
-      .catch((err) => err) .then((err) => {
-        expect(err).to.be.an.instanceof(Errors.NotFound);
       });
     });
 

--- a/test/plugins/features/captures/index.test.js
+++ b/test/plugins/features/captures/index.test.js
@@ -65,7 +65,7 @@ describe('capture integration', () => {
       })
       .then((res) => {
         expect(res.statusCode).to.eql(200);
-        expect(res.result.pokemon.national_id).to.eql(secondPokemon.national_id);
+        expect(res.result[0].pokemon.national_id).to.eql(secondPokemon.national_id);
       });
     });
 


### PR DESCRIPTION
accept an array of pokemon ids instead just a single id (though a single id is still valid) so that we can mark entire boxes/rows as captured

fixes https://github.com/robinjoseph08/pokedextracker.com/issues/101