### PR TITLE
fix(users): check for duplicate usernames to prevent skipping ids

### DIFF
--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -28,6 +28,13 @@ exports.create = function (payload, request) {
     payload.password = hash;
     payload.last_ip = ip;
 
+    return new User().where('username', payload.username).fetch();
+  })
+  .then((user) => {
+    if (user) {
+      throw new Errors.ExistingUsername();
+    }
+
     return new User(payload).save();
   })
   .then((user) => JWT.sign(user))

--- a/test/plugins/features/users/controller.test.js
+++ b/test/plugins/features/users/controller.test.js
@@ -1,5 +1,7 @@
 'use strict';
 
+const Sinon = require('sinon');
+
 const Controller = require('../../../../src/plugins/features/users/controller');
 const Errors     = require('../../../../src/libraries/errors');
 const Knex       = require('../../../../src/libraries/knex');
@@ -92,6 +94,19 @@ describe('user controller', () => {
       .catch((err) => err)
       .then((err) => {
         expect(err).to.be.an.instanceof(Errors.ExistingUsername);
+      });
+    });
+
+    it('rejects if the username is taken after the fetch', () => {
+      Sinon.stub(User.prototype, 'save').throws(new Error('duplicate key value'));
+
+      return Controller.create({ username: firstUser.username, password: 'test' }, request)
+      .catch((err) => err)
+      .then((err) => {
+        expect(err).to.be.an.instanceof(Errors.ExistingUsername);
+      })
+      .finally(() => {
+        User.prototype.save.restore();
       });
     });
 


### PR DESCRIPTION
Fixes https://github.com/robinjoseph08/pokedextracker.com/issues/118

when a duplicate username is used an the db rejects it due to the duplicate key constraint, it "wastes" an id. by checking prior to the save, we can reduce the number of skipped ids. it wont completely get rid of it (since someone could signup in between the fetch and the save), but thats a very rare case.