### PR TITLE
chore(npm): shrinkwrap dev dependencies

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -245,6 +245,11 @@
       "from": "center-align@>=0.1.1 <0.2.0",
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz"
     },
+    "chai": {
+      "version": "3.5.0",
+      "from": "chai@>=3.5.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-3.5.0.tgz"
+    },
     "chalk": {
       "version": "1.1.1",
       "from": "chalk@>=1.0.0 <2.0.0",
@@ -322,10 +327,36 @@
       "from": "core-util-is@>=1.0.0 <1.1.0",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz"
     },
+    "coveralls": {
+      "version": "2.11.9",
+      "from": "coveralls@>=2.11.8 <3.0.0",
+      "resolved": "https://registry.npmjs.org/coveralls/-/coveralls-2.11.9.tgz",
+      "dependencies": {
+        "argparse": {
+          "version": "0.1.16",
+          "from": "argparse@>=0.1.11 <0.2.0",
+          "resolved": "https://registry.npmjs.org/argparse/-/argparse-0.1.16.tgz"
+        },
+        "esprima": {
+          "version": "1.0.4",
+          "from": "esprima@>=1.0.2 <1.1.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.0.4.tgz"
+        },
+        "js-yaml": {
+          "version": "3.0.1",
+          "from": "js-yaml@3.0.1",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.0.1.tgz"
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "from": "minimist@1.2.0"
+        }
+      }
+    },
     "create-boom-error": {
       "version": "0.1.0",
-      "from": "create-boom-error@*",
-      "resolved": "https://registry.npmjs.org/create-boom-error/-/create-boom-error-0.1.0.tgz",
+      "from": "create-boom-error@latest",
+      "resolved": "http://registry.nodejitsu.com/create-boom-error/-/create-boom-error-0.1.0.tgz",
       "dependencies": {
         "boom": {
           "version": "2.10.1",
@@ -508,29 +539,43 @@
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz"
     },
     "escodegen": {
-      "version": "1.7.1",
-      "from": "escodegen@>=1.7.0 <1.8.0",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.7.1.tgz",
+      "version": "1.8.0",
+      "from": "escodegen@>=1.8.0 <1.9.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.8.0.tgz",
       "dependencies": {
         "esprima": {
-          "version": "1.2.5",
-          "from": "esprima@>=1.2.2 <2.0.0",
-          "resolved": "https://registry.npmjs.org/esprima/-/esprima-1.2.5.tgz"
+          "version": "2.7.2",
+          "from": "esprima@>=2.7.1 <3.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
         },
         "estraverse": {
           "version": "1.9.3",
           "from": "estraverse@>=1.9.1 <2.0.0",
           "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-1.9.3.tgz"
         },
+        "fast-levenshtein": {
+          "version": "1.1.3",
+          "from": "fast-levenshtein@>=1.1.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-1.1.3.tgz"
+        },
+        "levn": {
+          "version": "0.3.0",
+          "from": "levn@>=0.3.0 <0.4.0",
+          "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz"
+        },
         "optionator": {
-          "version": "0.5.0",
-          "from": "optionator@>=0.5.0 <0.6.0",
-          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.5.0.tgz"
+          "version": "0.8.1",
+          "from": "optionator@>=0.8.1 <0.9.0",
+          "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.1.tgz"
         },
         "source-map": {
           "version": "0.2.0",
           "from": "source-map@>=0.2.0 <0.3.0",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.2.0.tgz"
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "from": "wordwrap@>=1.0.0 <1.1.0"
         }
       }
     },
@@ -538,6 +583,16 @@
       "version": "3.5.0",
       "from": "escope@>=3.4.0 <4.0.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.5.0.tgz"
+    },
+    "eslint": {
+      "version": "1.10.3",
+      "from": "eslint@>=1.10.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.10.3.tgz"
+    },
+    "eslint-config-lob": {
+      "version": "2.0.1",
+      "from": "eslint-config-lob@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-lob/-/eslint-config-lob-2.0.1.tgz"
     },
     "espree": {
       "version": "2.2.5",
@@ -1316,6 +1371,11 @@
         }
       }
     },
+    "generate-changelog": {
+      "version": "1.0.1",
+      "from": "generate-changelog@>=1.0.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/generate-changelog/-/generate-changelog-1.0.1.tgz"
+    },
     "generate-function": {
       "version": "2.0.0",
       "from": "generate-function@>=2.0.0 <3.0.0",
@@ -1584,7 +1644,8 @@
         },
         "hoek": {
           "version": "2.16.3",
-          "from": "hoek@>=2.0.0 <3.0.0"
+          "from": "hoek@2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         }
       }
     },
@@ -1627,7 +1688,8 @@
     },
     "hoek": {
       "version": "3.0.4",
-      "from": "hoek@>=3.0.0 <4.0.0"
+      "from": "hoek@3.0.4",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-3.0.4.tgz"
     },
     "http-signature": {
       "version": "1.1.1",
@@ -1651,7 +1713,8 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@>=1.1.0 <2.0.0"
+          "from": "minimist@1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
@@ -1679,6 +1742,17 @@
       "version": "1.3.4",
       "from": "ini@>=1.3.0 <1.4.0",
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.4.tgz"
+    },
+    "inject-then": {
+      "version": "2.0.5",
+      "from": "inject-then@>=2.0.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/inject-then/-/inject-then-2.0.5.tgz",
+      "dependencies": {
+        "bluebird": {
+          "version": "2.10.2",
+          "from": "bluebird@>=2.3.11 <3.0.0"
+        }
+      }
     },
     "inquirer": {
       "version": "0.11.4",
@@ -1812,7 +1886,8 @@
     },
     "isemail": {
       "version": "2.1.0",
-      "from": "isemail@>=2.0.0 <3.0.0"
+      "from": "isemail@2.1.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.1.0.tgz"
     },
     "isexe": {
       "version": "1.1.2",
@@ -1828,6 +1903,33 @@
       "version": "0.1.2",
       "from": "isstream@>=0.1.2 <0.2.0",
       "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz"
+    },
+    "istanbul": {
+      "version": "0.4.3",
+      "from": "istanbul@>=0.4.2 <0.5.0",
+      "resolved": "https://registry.npmjs.org/istanbul/-/istanbul-0.4.3.tgz",
+      "dependencies": {
+        "esprima": {
+          "version": "2.7.2",
+          "from": "esprima@>=2.7.0 <2.8.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-2.7.2.tgz"
+        },
+        "nopt": {
+          "version": "3.0.6",
+          "from": "nopt@>=3.0.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/nopt/-/nopt-3.0.6.tgz"
+        },
+        "supports-color": {
+          "version": "3.1.2",
+          "from": "supports-color@>=3.1.0 <4.0.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-3.1.2.tgz"
+        },
+        "wordwrap": {
+          "version": "1.0.0",
+          "from": "wordwrap@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz"
+        }
+      }
     },
     "jade": {
       "version": "0.26.3",
@@ -1930,7 +2032,8 @@
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@>=2.9.24 <3.0.0"
+          "from": "bluebird@2.10.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         },
         "minimist": {
           "version": "1.1.3",
@@ -1971,7 +2074,8 @@
       "dependencies": {
         "minimist": {
           "version": "1.1.3",
-          "from": "minimist@>=1.1.0 <1.2.0"
+          "from": "minimist@1.1.3",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
         }
       }
     },
@@ -2217,6 +2321,43 @@
       "from": "mkdirp@>=0.5.0 <0.6.0",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz"
     },
+    "mocha": {
+      "version": "2.4.5",
+      "from": "mocha@>=2.4.5 <3.0.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-2.4.5.tgz",
+      "dependencies": {
+        "commander": {
+          "version": "2.3.0",
+          "from": "commander@2.3.0",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.3.0.tgz"
+        },
+        "escape-string-regexp": {
+          "version": "1.0.2",
+          "from": "escape-string-regexp@1.0.2",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.2.tgz"
+        },
+        "glob": {
+          "version": "3.2.3",
+          "from": "glob@3.2.3",
+          "resolved": "https://registry.npmjs.org/glob/-/glob-3.2.3.tgz"
+        },
+        "graceful-fs": {
+          "version": "2.0.3",
+          "from": "graceful-fs@>=2.0.0 <2.1.0",
+          "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-2.0.3.tgz"
+        },
+        "minimatch": {
+          "version": "0.2.14",
+          "from": "minimatch@>=0.2.11 <0.3.0",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-0.2.14.tgz"
+        },
+        "supports-color": {
+          "version": "1.2.0",
+          "from": "supports-color@1.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-1.2.0.tgz"
+        }
+      }
+    },
     "moment": {
       "version": "2.11.2",
       "from": "moment@>=2.0.0 <3.0.0",
@@ -2373,6 +2514,11 @@
       "version": "1.4.7",
       "from": "node-uuid@>=1.4.7 <1.5.0",
       "resolved": "https://registry.npmjs.org/node-uuid/-/node-uuid-1.4.7.tgz"
+    },
+    "nodemon": {
+      "version": "1.9.2",
+      "from": "nodemon@>=1.9.1 <2.0.0",
+      "resolved": "https://registry.npmjs.org/nodemon/-/nodemon-1.9.2.tgz"
     },
     "nopt": {
       "version": "1.0.10",
@@ -2679,6 +2825,11 @@
         }
       }
     },
+    "rosie": {
+      "version": "1.3.0",
+      "from": "rosie@>=1.3.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/rosie/-/rosie-1.3.0.tgz"
+    },
     "run-async": {
       "version": "0.1.0",
       "from": "run-async@>=0.1.0 <0.2.0",
@@ -2719,6 +2870,11 @@
       "from": "simple-backoff@>=1.0.0 <2.0.0",
       "resolved": "https://registry.npmjs.org/simple-backoff/-/simple-backoff-1.0.0.tgz"
     },
+    "sinon": {
+      "version": "1.17.4",
+      "from": "sinon@>=1.17.3 <2.0.0",
+      "resolved": "https://registry.npmjs.org/sinon/-/sinon-1.17.4.tgz"
+    },
     "slide": {
       "version": "1.1.6",
       "from": "slide@>=1.1.5 <2.0.0",
@@ -2731,7 +2887,8 @@
       "dependencies": {
         "hoek": {
           "version": "2.16.3",
-          "from": "hoek@>=2.0.0 <3.0.0"
+          "from": "hoek@2.16.3",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
         }
       }
     },
@@ -2824,7 +2981,8 @@
     },
     "topo": {
       "version": "2.0.0",
-      "from": "topo@>=2.0.0 <3.0.0"
+      "from": "topo@2.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.0.tgz"
     },
     "touch": {
       "version": "1.0.0",
@@ -2935,7 +3093,8 @@
       "dependencies": {
         "user-home": {
           "version": "1.1.1",
-          "from": "user-home@>=1.1.1 <2.0.0"
+          "from": "user-home@1.1.1",
+          "resolved": "https://registry.npmjs.org/user-home/-/user-home-1.1.1.tgz"
         }
       }
     },


### PR DESCRIPTION
Shrinkwrap dev dependencies so that when other people clone the repo and install the dependencies, all of the packages' versions are as expected.