### PR TITLE
chore(lint): update eslint-config-lob from 2.0.0 to 2.2.0

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,8 +3,5 @@
   "globals": {
     "expect": false,
     "Factory": false
-  },
-  "rules": {
-    "arrow-body-style": 0
   }
 }

--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -590,9 +590,8 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-1.10.3.tgz"
     },
     "eslint-config-lob": {
-      "version": "2.0.1",
-      "from": "eslint-config-lob@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-lob/-/eslint-config-lob-2.0.1.tgz"
+      "version": "2.2.0",
+      "from": "eslint-config-lob@latest"
     },
     "espree": {
       "version": "2.2.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "chai": "^3.5.0",
     "coveralls": "^2.11.8",
     "eslint": "^1.10.3",
-    "eslint-config-lob": "^2.0.0",
+    "eslint-config-lob": "^2.2.0",
     "generate-changelog": "^1.0.1",
     "inject-then": "^2.0.5",
     "istanbul": "^0.4.2",

--- a/src/libraries/bookshelf.js
+++ b/src/libraries/bookshelf.js
@@ -6,4 +6,4 @@ const Knex = require('./knex');
 
 module.exports = Bookshelf(Knex);
 
-module.exports.plugin(['registry', 'virtuals'])
+module.exports.plugin(['registry', 'virtuals']);

--- a/src/server.js
+++ b/src/server.js
@@ -34,7 +34,7 @@ server.register([
   if (err) {
     throw err;
   }
-})
+});
 
 /* istanbul ignore next */
 process.on('SIGTERM', () => {

--- a/test/models/pokemon.test.js
+++ b/test/models/pokemon.test.js
@@ -176,8 +176,8 @@ describe('pokemon model', () => {
       .then((json) => json.evolution_family.pokemon)
       .map((poke) => poke.map((p) => p.national_id))
       .then((poke) => {
-        expect(poke[0]).to.include(firstPokemon.national_id)
-        expect(poke[1]).to.include(secondPokemon.national_id)
+        expect(poke[0]).to.include(firstPokemon.national_id);
+        expect(poke[1]).to.include(secondPokemon.national_id);
       });
     });
 

--- a/test/plugins/services/auth.test.js
+++ b/test/plugins/services/auth.test.js
@@ -15,7 +15,7 @@ describe('auth service plugin', () => {
     server.register([
       require('inject-then'),
       require('../../../src/plugins/services/auth')
-    ], () => {})
+    ], () => {});
 
     server.route([{
       method: 'GET',

--- a/test/plugins/services/errors.test.js
+++ b/test/plugins/services/errors.test.js
@@ -16,7 +16,7 @@ describe('errors service plugin', () => {
     server.register([
       require('inject-then'),
       require('../../../src/plugins/services/errors')
-    ], () => {})
+    ], () => {});
 
     server.route([{
       method: 'GET',


### PR DESCRIPTION
A few more rules were fixed in the latest version of the eslint config (such as the `arrow-body-style` fix and enabling `semi`).