### PR TITLE
chore(deps): update pg, knex, bookshelf

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -107,27 +107,10 @@
       "from": "aws-sign2@>=0.6.0 <0.7.0",
       "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.6.0.tgz"
     },
-    "babel-polyfill": {
-      "version": "6.6.1",
-      "from": "babel-polyfill@>=6.0.16 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.6.1.tgz"
-    },
-    "babel-regenerator-runtime": {
-      "version": "6.5.0",
-      "from": "babel-regenerator-runtime@>=6.3.13 <7.0.0",
-      "resolved": "https://registry.npmjs.org/babel-regenerator-runtime/-/babel-regenerator-runtime-6.5.0.tgz"
-    },
     "babel-runtime": {
-      "version": "5.8.35",
-      "from": "babel-runtime@>=5.0.0 <6.0.0",
-      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-5.8.35.tgz",
-      "dependencies": {
-        "core-js": {
-          "version": "1.2.6",
-          "from": "core-js@>=1.0.0 <2.0.0",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.6.tgz"
-        }
-      }
+      "version": "6.9.2",
+      "from": "babel-runtime@>=6.6.1 <7.0.0",
+      "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.9.2.tgz"
     },
     "balanced-match": {
       "version": "0.3.0",
@@ -189,14 +172,19 @@
       "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.3.3.tgz"
     },
     "bookshelf": {
-      "version": "0.9.2",
-      "from": "bookshelf@*",
-      "resolved": "https://registry.npmjs.org/bookshelf/-/bookshelf-0.9.2.tgz",
+      "version": "0.10.0",
+      "from": "bookshelf@latest",
+      "resolved": "https://registry.npmjs.org/bookshelf/-/bookshelf-0.10.0.tgz",
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
           "from": "bluebird@>=2.9.4 <3.0.0",
           "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@>=4.13.1 <5.0.0",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         }
       }
     },
@@ -318,9 +306,9 @@
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-1.4.0.tgz"
     },
     "core-js": {
-      "version": "2.1.3",
-      "from": "core-js@>=2.1.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.1.3.tgz"
+      "version": "2.4.0",
+      "from": "core-js@>=2.4.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.4.0.tgz"
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -349,7 +337,8 @@
         },
         "minimist": {
           "version": "1.2.0",
-          "from": "minimist@1.2.0"
+          "from": "minimist@1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz"
         }
       }
     },
@@ -646,9 +635,9 @@
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.1.tgz"
     },
     "extend": {
-      "version": "2.0.1",
-      "from": "extend@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-2.0.1.tgz"
+      "version": "3.0.0",
+      "from": "extend@>=3.0.0 <4.0.0",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.0.tgz"
     },
     "extglob": {
       "version": "0.3.2",
@@ -698,26 +687,14 @@
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz"
     },
     "findup-sync": {
-      "version": "0.2.1",
-      "from": "findup-sync@>=0.2.0 <0.3.0",
-      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.2.1.tgz",
-      "dependencies": {
-        "glob": {
-          "version": "4.3.5",
-          "from": "glob@>=4.3.0 <4.4.0",
-          "resolved": "https://registry.npmjs.org/glob/-/glob-4.3.5.tgz"
-        },
-        "minimatch": {
-          "version": "2.0.10",
-          "from": "minimatch@>=2.0.1 <3.0.0",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-2.0.10.tgz"
-        }
-      }
+      "version": "0.3.0",
+      "from": "findup-sync@>=0.3.0 <0.4.0",
+      "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-0.3.0.tgz"
     },
     "flagged-respawn": {
-      "version": "0.3.1",
-      "from": "flagged-respawn@>=0.3.0 <0.4.0",
-      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.1.tgz"
+      "version": "0.3.2",
+      "from": "flagged-respawn@>=0.3.2 <0.4.0",
+      "resolved": "https://registry.npmjs.org/flagged-respawn/-/flagged-respawn-0.3.2.tgz"
     },
     "flat-cache": {
       "version": "1.0.10",
@@ -1388,9 +1365,9 @@
       "resolved": "https://registry.npmjs.org/generate-object-property/-/generate-object-property-1.2.0.tgz"
     },
     "generic-pool": {
-      "version": "2.1.1",
-      "from": "generic-pool@2.1.1",
-      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.1.1.tgz"
+      "version": "2.4.2",
+      "from": "generic-pool@2.4.2",
+      "resolved": "https://registry.npmjs.org/generic-pool/-/generic-pool-2.4.2.tgz"
     },
     "get-stdin": {
       "version": "4.0.1",
@@ -1666,9 +1643,9 @@
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-1.0.0.tgz"
     },
     "hashmap": {
-      "version": "2.0.4",
+      "version": "2.0.6",
       "from": "hashmap@>=2.0.1 <3.0.0",
-      "resolved": "https://registry.npmjs.org/hashmap/-/hashmap-2.0.4.tgz"
+      "resolved": "https://registry.npmjs.org/hashmap/-/hashmap-2.0.6.tgz"
     },
     "hawk": {
       "version": "3.1.3",
@@ -1725,9 +1702,9 @@
       "resolved": "https://registry.npmjs.org/infinity-agent/-/infinity-agent-2.0.3.tgz"
     },
     "inflection": {
-      "version": "1.8.0",
+      "version": "1.10.0",
       "from": "inflection@>=1.5.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.8.0.tgz"
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-1.10.0.tgz"
     },
     "inflight": {
       "version": "1.0.4",
@@ -1751,7 +1728,8 @@
       "dependencies": {
         "bluebird": {
           "version": "2.10.2",
-          "from": "bluebird@>=2.3.11 <3.0.0"
+          "from": "bluebird@2.10.2",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
         }
       }
     },
@@ -2027,14 +2005,18 @@
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.0.2.tgz"
     },
     "knex": {
-      "version": "0.10.0",
-      "from": "knex@*",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-0.10.0.tgz",
+      "version": "0.11.7",
+      "from": "knex@latest",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-0.11.7.tgz",
       "dependencies": {
         "bluebird": {
-          "version": "2.10.2",
-          "from": "bluebird@2.10.2",
-          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.10.2.tgz"
+          "version": "3.4.1",
+          "from": "bluebird@>=3.3.4 <4.0.0",
+          "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.4.1.tgz"
+        },
+        "lodash": {
+          "version": "4.13.1",
+          "from": "lodash@>=4.6.0 <5.0.0"
         },
         "minimist": {
           "version": "1.1.3",
@@ -2042,9 +2024,9 @@
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
         },
         "readable-stream": {
-          "version": "1.1.13",
+          "version": "1.1.14",
           "from": "readable-stream@>=1.1.12 <2.0.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
@@ -2074,16 +2056,9 @@
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.2.5.tgz"
     },
     "liftoff": {
-      "version": "2.0.3",
-      "from": "liftoff@>=2.0.0 <2.1.0",
-      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.0.3.tgz",
-      "dependencies": {
-        "minimist": {
-          "version": "1.1.3",
-          "from": "minimist@1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz"
-        }
-      }
+      "version": "2.2.4",
+      "from": "liftoff@>=2.2.0 <2.3.0",
+      "resolved": "https://registry.npmjs.org/liftoff/-/liftoff-2.2.4.tgz"
     },
     "lodash": {
       "version": "3.10.1",
@@ -2622,14 +2597,14 @@
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz"
     },
     "pg": {
-      "version": "4.5.1",
-      "from": "pg@*",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-4.5.1.tgz",
+      "version": "6.0.2",
+      "from": "pg@latest",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-6.0.2.tgz",
       "dependencies": {
         "semver": {
-          "version": "4.3.6",
-          "from": "semver@>=4.1.0 <5.0.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.6.tgz"
+          "version": "4.3.2",
+          "from": "semver@4.3.2",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-4.3.2.tgz"
         }
       }
     },
@@ -2638,15 +2613,34 @@
       "from": "pg-connection-string@>=0.1.3 <0.2.0",
       "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-0.1.3.tgz"
     },
+    "pg-pool": {
+      "version": "1.3.1",
+      "from": "pg-pool@>=1.0.0 <2.0.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-1.3.1.tgz",
+      "dependencies": {
+        "object-assign": {
+          "version": "4.1.0",
+          "from": "object-assign@4.1.0",
+          "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.0.tgz"
+        }
+      }
+    },
     "pg-types": {
-      "version": "1.10.0",
+      "version": "1.11.0",
       "from": "pg-types@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.10.0.tgz"
+      "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-1.11.0.tgz"
     },
     "pgpass": {
-      "version": "0.0.3",
-      "from": "pgpass@0.0.3",
-      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.3.tgz"
+      "version": "0.0.6",
+      "from": "pgpass@0.0.6",
+      "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-0.0.6.tgz",
+      "dependencies": {
+        "split": {
+          "version": "1.0.0",
+          "from": "split@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/split/-/split-1.0.0.tgz"
+        }
+      }
     },
     "pify": {
       "version": "2.3.0",
@@ -2664,9 +2658,9 @@
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.0.tgz"
     },
     "pool2": {
-      "version": "1.3.1",
+      "version": "1.3.4",
       "from": "pool2@>=1.1.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/pool2/-/pool2-1.3.1.tgz"
+      "resolved": "https://registry.npmjs.org/pool2/-/pool2-1.3.4.tgz"
     },
     "postgres-array": {
       "version": "1.0.0",
@@ -2679,14 +2673,14 @@
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz"
     },
     "postgres-date": {
-      "version": "1.0.1",
+      "version": "1.0.3",
       "from": "postgres-date@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.3.tgz"
     },
     "postgres-interval": {
-      "version": "1.0.1",
+      "version": "1.0.2",
       "from": "postgres-interval@>=1.0.0 <1.1.0",
-      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.1.tgz"
+      "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.0.2.tgz"
     },
     "prelude-ls": {
       "version": "1.1.2",
@@ -2766,6 +2760,16 @@
       "version": "1.0.1",
       "from": "readline2@>=1.0.1 <2.0.0",
       "resolved": "https://registry.npmjs.org/readline2/-/readline2-1.0.1.tgz"
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "from": "rechoir@>=0.6.2 <0.7.0",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz"
+    },
+    "regenerator-runtime": {
+      "version": "0.9.5",
+      "from": "regenerator-runtime@>=0.9.5 <0.10.0",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.9.5.tgz"
     },
     "regex-cache": {
       "version": "0.4.2",

--- a/package.json
+++ b/package.json
@@ -20,17 +20,17 @@
   },
   "dependencies": {
     "bcrypt": "^0.8.5",
-    "bookshelf": "^0.9.2",
+    "bookshelf": "^0.10.0",
     "create-boom-error": "^0.1.0",
     "hapi": "^13.0.0",
     "hapi-auth-jwt": "^4.0.0",
     "hapi-bookshelf-serializer": "^2.1.0",
     "joi": "^8.0.4",
     "jsonwebtoken": "^5.7.0",
-    "knex": "^0.10.0",
+    "knex": "^0.11.7",
     "left-pad": "^1.1.1",
     "newrelic": "^1.26.0",
-    "pg": "^4.5.1"
+    "pg": "^6.0.2"
   },
   "devDependencies": {
     "chai": "^3.5.0",


### PR DESCRIPTION
Update db dependencies:

- `pg` v4.5.1 -> v6.0.2
- `knex` v0.10.0 -> v0.11.7
- `bookshelf` v0.9.2 -> v0.10.0

it doesn't look like the breaking changes from the major upgrades affects the repo, so no changes are need. `pg` changed some of its pool implementation, `knex` changed the way `QueryBuilder#orWhere` is handled, and bookshelf changed some lodash functions on `CollectionBase`.