### PR TITLE
chore(deps): update joi from 8.0.4 to 9.0.0

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -1864,9 +1864,9 @@
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz"
     },
     "isemail": {
-      "version": "2.1.0",
-      "from": "isemail@2.1.0",
-      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.1.0.tgz"
+      "version": "2.2.0",
+      "from": "isemail@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/isemail/-/isemail-2.2.0.tgz"
     },
     "isexe": {
       "version": "1.1.2",
@@ -1910,6 +1910,11 @@
         }
       }
     },
+    "items": {
+      "version": "2.1.0",
+      "from": "items@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/items/-/items-2.1.0.tgz"
+    },
     "jade": {
       "version": "0.26.3",
       "from": "jade@0.26.3",
@@ -1933,9 +1938,16 @@
       "resolved": "https://registry.npmjs.org/jodid25519/-/jodid25519-1.0.2.tgz"
     },
     "joi": {
-      "version": "8.0.4",
-      "from": "joi@*",
-      "resolved": "https://registry.npmjs.org/joi/-/joi-8.0.4.tgz"
+      "version": "9.0.0",
+      "from": "joi@latest",
+      "resolved": "https://registry.npmjs.org/joi/-/joi-9.0.0.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "4.0.1",
+          "from": "hoek@>=4.0.0 <5.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.0.1.tgz"
+        }
+      }
     },
     "js-yaml": {
       "version": "3.4.5",
@@ -2016,7 +2028,8 @@
         },
         "lodash": {
           "version": "4.13.1",
-          "from": "lodash@>=4.6.0 <5.0.0"
+          "from": "lodash@4.13.1",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.13.1.tgz"
         },
         "minimist": {
           "version": "1.1.3",
@@ -2340,9 +2353,9 @@
       }
     },
     "moment": {
-      "version": "2.11.2",
+      "version": "2.14.1",
       "from": "moment@>=2.0.0 <3.0.0",
-      "resolved": "https://registry.npmjs.org/moment/-/moment-2.11.2.tgz"
+      "resolved": "https://registry.npmjs.org/moment/-/moment-2.14.1.tgz"
     },
     "ms": {
       "version": "0.7.1",
@@ -2990,9 +3003,15 @@
       "resolved": "https://registry.npmjs.org/timed-out/-/timed-out-2.0.0.tgz"
     },
     "topo": {
-      "version": "2.0.0",
-      "from": "topo@2.0.0",
-      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.0.tgz"
+      "version": "2.0.1",
+      "from": "topo@>=2.0.0 <3.0.0",
+      "resolved": "https://registry.npmjs.org/topo/-/topo-2.0.1.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "4.0.1",
+          "from": "hoek@>=4.0.0 <5.0.0"
+        }
+      }
     },
     "touch": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "hapi": "^13.0.0",
     "hapi-auth-jwt": "^4.0.0",
     "hapi-bookshelf-serializer": "^2.1.0",
-    "joi": "^8.0.4",
+    "joi": "^9.0.0",
     "jsonwebtoken": "^5.7.0",
     "knex": "^0.11.7",
     "left-pad": "^1.1.1",


### PR DESCRIPTION
update to v9 of joi which is a small change that just makes joi a bit more extensible and and changes the way `.options` work, but it didn't change the way this repo uses it.