### PR TITLE
chore(deps): update jsonwebtoken from 5.7.0 to 7.1.3

### DIFF
--- a/npm-shrinkwrap.json
+++ b/npm-shrinkwrap.json
@@ -118,9 +118,9 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.3.0.tgz"
     },
     "base64-url": {
-      "version": "1.2.1",
+      "version": "1.2.2",
       "from": "base64-url@>=1.2.1 <2.0.0",
-      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.1.tgz"
+      "resolved": "https://registry.npmjs.org/base64-url/-/base64-url-1.2.2.tgz"
     },
     "base64url": {
       "version": "1.0.6",
@@ -133,9 +133,9 @@
           "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.4.10.tgz"
         },
         "readable-stream": {
-          "version": "1.1.13",
+          "version": "1.1.14",
           "from": "readable-stream@>=1.1.9 <1.2.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.13.tgz"
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.1.14.tgz"
         }
       }
     },
@@ -478,9 +478,9 @@
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.1.tgz"
     },
     "ecdsa-sig-formatter": {
-      "version": "1.0.5",
+      "version": "1.0.7",
       "from": "ecdsa-sig-formatter@>=1.0.0 <2.0.0",
-      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.5.tgz"
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.7.tgz"
     },
     "end-of-stream": {
       "version": "1.0.0",
@@ -1603,7 +1603,14 @@
     "hapi-auth-jwt": {
       "version": "4.0.0",
       "from": "hapi-auth-jwt@*",
-      "resolved": "https://registry.npmjs.org/hapi-auth-jwt/-/hapi-auth-jwt-4.0.0.tgz"
+      "resolved": "https://registry.npmjs.org/hapi-auth-jwt/-/hapi-auth-jwt-4.0.0.tgz",
+      "dependencies": {
+        "jsonwebtoken": {
+          "version": "5.7.0",
+          "from": "jsonwebtoken@>=5.0.0 <6.0.0",
+          "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz"
+        }
+      }
     },
     "hapi-bookshelf-serializer": {
       "version": "2.1.0",
@@ -1992,9 +1999,31 @@
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-2.0.0.tgz"
     },
     "jsonwebtoken": {
-      "version": "5.7.0",
-      "from": "jsonwebtoken@*",
-      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-5.7.0.tgz"
+      "version": "7.1.3",
+      "from": "jsonwebtoken@latest",
+      "resolved": "https://registry.npmjs.org/jsonwebtoken/-/jsonwebtoken-7.1.3.tgz",
+      "dependencies": {
+        "hoek": {
+          "version": "2.16.3",
+          "from": "hoek@>=2.0.0 <3.0.0",
+          "resolved": "https://registry.npmjs.org/hoek/-/hoek-2.16.3.tgz"
+        },
+        "isemail": {
+          "version": "1.2.0",
+          "from": "isemail@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/isemail/-/isemail-1.2.0.tgz"
+        },
+        "joi": {
+          "version": "6.10.1",
+          "from": "joi@>=6.10.1 <6.11.0",
+          "resolved": "https://registry.npmjs.org/joi/-/joi-6.10.1.tgz"
+        },
+        "topo": {
+          "version": "1.1.0",
+          "from": "topo@>=1.0.0 <2.0.0",
+          "resolved": "https://registry.npmjs.org/topo/-/topo-1.1.0.tgz"
+        }
+      }
     },
     "jsprim": {
       "version": "1.2.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "hapi-auth-jwt": "^4.0.0",
     "hapi-bookshelf-serializer": "^2.1.0",
     "joi": "^9.0.0",
-    "jsonwebtoken": "^5.7.0",
+    "jsonwebtoken": "^7.1.3",
     "knex": "^0.11.7",
     "left-pad": "^1.1.1",
     "newrelic": "^1.26.0",

--- a/src/libraries/jwt.js
+++ b/src/libraries/jwt.js
@@ -7,6 +7,6 @@ const Config = require('../../config');
 
 exports.sign = function (user) {
   return new Bluebird((resolve) => {
-    JWT.sign(user.serialize(), Config.JWT_SECRET, {}, (token) => resolve({ token }));
+    JWT.sign(user.serialize(), Config.JWT_SECRET, {}, (err, token) => resolve({ token }));
   });
 };


### PR DESCRIPTION
update jwt where the main breaking changes involve improvements to the `.sign` function. it makes it more node-y by providing err-first callbacks. since this repo uses that function, we just needed to adjust it but expecting the err as the first arg. luckily we have a test for that.