### PR TITLE
chore(bluebird): only enable long stack traces for tests

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -1,12 +1,9 @@
 'use strict';
 
-const Bluebird = require('bluebird');
-const Hapi     = require('hapi');
-const Util     = require('util');
+const Hapi = require('hapi');
+const Util = require('util');
 
 const Config = require('../config');
-
-Bluebird.longStackTraces();
 
 const server = new Hapi.Server({
   connections: {

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,7 +1,10 @@
 'use strict';
 
-const Chai  = require('chai');
-const Rosie = require('rosie');
+const Bluebird = require('bluebird');
+const Chai     = require('chai');
+const Rosie    = require('rosie');
+
+Bluebird.config({ longStackTraces: true });
 
 global.expect = Chai.expect;
 global.Factory = Rosie.Factory;


### PR DESCRIPTION
it is [not recommended](http://bluebirdjs.com/docs/api/promise.longstacktraces.html) to enable long stack traces in production