### PR TITLE
fix(users): update endpoint returns a new session

### DIFF
--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -37,6 +37,7 @@ exports.create = function (payload, request) {
 
     return new User(payload).save();
   })
+  .then((user) => user.refresh())
   .then((user) => JWT.sign(user))
   .catch(Errors.DuplicateKey, () => {
     throw new Errors.ExistingUsername();
@@ -45,6 +46,8 @@ exports.create = function (payload, request) {
 
 exports.update = function (username, payload, auth) {
   return new User({ id: auth.id }).where('username', username).save(payload)
+  .then((user) => user.refresh())
+  .then((user) => JWT.sign(user))
   .catch(User.NoRowsUpdatedError, () => {
     throw new Errors.ForbiddenAction('updating this user');
   });

--- a/test/plugins/features/users/controller.test.js
+++ b/test/plugins/features/users/controller.test.js
@@ -122,9 +122,18 @@ describe('user controller', () => {
       const friendCode = '4321-4321-4321';
 
       return Controller.update(firstUser.username, { friend_code: friendCode }, { id: firstUser.id })
-      .then((user) => new User({ id: user.id }).fetch())
+      .then(() => new User({ id: firstUser.id }).fetch())
       .then((user) => {
         expect(user.get('friend_code')).to.eql(friendCode);
+      });
+    });
+
+    it('returns a new session', () => {
+      const friendCode = '4321-4321-4321';
+
+      return Controller.update(firstUser.username, { friend_code: friendCode }, { id: firstUser.id })
+      .then((session) => {
+        expect(session.token).to.be.a('string');
       });
     });
 


### PR DESCRIPTION
when updating a user, a new session needs to be returned so that it can be saved on the client-side. this will be more useful when we add more preferences (preferred language, etc)