### PR TITLE
fix(hapi): enable getLog()

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -11,7 +11,8 @@ const server = new Hapi.Server({
       stripTrailingSlash: true
     },
     routes: {
-      cors: { credentials: true }
+      cors: { credentials: true },
+      log: true
     }
   }
 });


### PR DESCRIPTION
hapi v15 disabled it by default but i think good uses it so its causing errors (as seen in new relic).