### PR TITLE
feat(users): add pagination to the list endpoint

### DIFF
--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -8,8 +8,13 @@ const Errors = require('../../../libraries/errors');
 const JWT    = require('../../../libraries/jwt');
 const User   = require('../../../models/user');
 
-exports.list = function () {
-  return new User().query((qb) => qb.orderBy('id', 'DESC')).fetchAll();
+exports.list = function (query) {
+  return new User().query((qb) => {
+    qb.orderBy('id', 'DESC');
+    qb.limit(query.limit);
+    qb.offset(query.offset);
+  })
+  .fetchAll();
 };
 
 exports.retrieve = function (username) {

--- a/src/plugins/features/users/index.js
+++ b/src/plugins/features/users/index.js
@@ -2,6 +2,7 @@
 
 const Controller          = require('./controller');
 const UserCreateValidator = require('../../../validators/user/create');
+const UserListValidator   = require('../../../validators/user/list');
 const UserUpdateValidator = require('../../../validators/user/update');
 
 exports.register = (server, options, next) => {
@@ -10,7 +11,8 @@ exports.register = (server, options, next) => {
     method: 'GET',
     path: '/users',
     config: {
-      handler: (request, reply) => reply(Controller.list())
+      handler: (request, reply) => reply(Controller.list(request.query)),
+      validate: { query: UserListValidator }
     }
   }, {
     method: 'GET',

--- a/src/validators/user/list.js
+++ b/src/validators/user/list.js
@@ -1,0 +1,14 @@
+'use strict';
+
+const Joi = require('joi');
+
+const LIMIT_DEFAULT  = 10;
+const LIMIT_MAX      = 100;
+const LIMIT_MIN      = 0;
+const OFFSET_DEFAULT = 0;
+const OFFSET_MIN     = 0;
+
+module.exports = Joi.object().keys({
+  limit: Joi.number().integer().min(LIMIT_MIN).max(LIMIT_MAX).default(LIMIT_DEFAULT),
+  offset: Joi.number().integer().min(OFFSET_MIN).default(OFFSET_DEFAULT)
+});

--- a/test/plugins/features/users/controller.test.js
+++ b/test/plugins/features/users/controller.test.js
@@ -20,13 +20,33 @@ describe('user controller', () => {
     });
 
     it('returns a collection of users ordered by id descending', () => {
-      return Controller.list()
+      return Controller.list({ limit: 10, offset: 0 })
       .get('models')
       .map((user) => user.id)
       .then((users) => {
         expect(users).to.have.length(2);
         expect(users[0]).to.eql(secondUser.id);
         expect(users[1]).to.eql(firstUser.id);
+      });
+    });
+
+    it('utilized a limit that is passed in', () => {
+      return Controller.list({ limit: 1, offset: 0 })
+      .get('models')
+      .map((user) => user.id)
+      .then((users) => {
+        expect(users).to.have.length(1);
+        expect(users[0]).to.eql(secondUser.id);
+      });
+    });
+
+    it('utilized an offset that is passed in', () => {
+      return Controller.list({ limit: 10, offset: 1 })
+      .get('models')
+      .map((user) => user.id)
+      .then((users) => {
+        expect(users).to.have.length(1);
+        expect(users[0]).to.eql(firstUser.id);
       });
     });
 

--- a/test/validators/user/list.test.js
+++ b/test/validators/user/list.test.js
@@ -1,0 +1,73 @@
+'use strict';
+
+const Joi = require('joi');
+
+const UserListValidator = require('../../../src/validators/user/list');
+
+describe('user list validator', () => {
+
+  describe('limit', () => {
+
+    it('requires integers', () => {
+      const data = { limit: 1.1 };
+      const result = Joi.validate(data, UserListValidator);
+
+      expect(result.error.details[0].path).to.eql('limit');
+      expect(result.error.details[0].type).to.eql('number.integer');
+    });
+
+    it('has a minimum of 0', () => {
+      const data = { limit: -1 };
+      const result = Joi.validate(data, UserListValidator);
+
+      expect(result.error.details[0].path).to.eql('limit');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('has a maximum of 100', () => {
+      const data = { limit: 101 };
+      const result = Joi.validate(data, UserListValidator);
+
+      expect(result.error.details[0].path).to.eql('limit');
+      expect(result.error.details[0].type).to.eql('number.max');
+    });
+
+    it('has a default of 10', () => {
+      const data = {};
+      const result = Joi.validate(data, UserListValidator);
+
+      expect(result.error).to.not.exist;
+      expect(result.value.limit).to.eql(10);
+    });
+
+  });
+
+  describe('offset', () => {
+
+    it('requires integers', () => {
+      const data = { offset: 1.1 };
+      const result = Joi.validate(data, UserListValidator);
+
+      expect(result.error.details[0].path).to.eql('offset');
+      expect(result.error.details[0].type).to.eql('number.integer');
+    });
+
+    it('has a minimum of 0', () => {
+      const data = { offset: -1 };
+      const result = Joi.validate(data, UserListValidator);
+
+      expect(result.error.details[0].path).to.eql('offset');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('has a default of 0', () => {
+      const data = {};
+      const result = Joi.validate(data, UserListValidator);
+
+      expect(result.error).to.not.exist;
+      expect(result.value.offset).to.eql(0);
+    });
+
+  });
+
+});


### PR DESCRIPTION
The user endpoint is the slowest endpoint according to New Relic and it's probably because it's loading several thousand users at a time. While pagination wasn't necessary in the beginning, it's becoming increasingly necessary.