### PR TITLE
fix(users): return user session on user create

### DIFF
--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -47,7 +47,7 @@ exports.create = function (payload, request) {
 
     return Knex.transaction((transacting) => {
       return new User().save(payload, { transacting })
-      .then((user) => {
+      .tap((user) => {
         return new Dex().save({
           user_id: user.id,
           title,

--- a/test/plugins/features/users/controller.test.js
+++ b/test/plugins/features/users/controller.test.js
@@ -1,5 +1,6 @@
 'use strict';
 
+const JWT   = require('jsonwebtoken');
 const Sinon = require('sinon');
 
 const Controller = require('../../../../src/plugins/features/users/controller');
@@ -85,13 +86,23 @@ describe('user controller', () => {
       const password = 'test';
 
       return Controller.create({ username, password }, request)
-      .then((session) => {
-        expect(session.token).to.be.a('string');
-      })
       .then(() => new User().where('username', username).fetch())
       .then((user) => {
         expect(user.get('password')).to.not.eql(password);
         expect(user.get('password')).to.have.length(60);
+      });
+    });
+
+    it('returns a session with a user token', () => {
+      const username = 'test';
+
+      return Controller.create({ username, password: 'test' }, request)
+      .then((session) => {
+        expect(session.token).to.be.a('string');
+
+        const user = JWT.decode(session.token);
+
+        expect(user.username).to.eql(username);
       });
     });
 


### PR DESCRIPTION
with #49, it was encoding the dex object into the jwt which caused a bad redirect on the frontend. this now makes it so that the user object is what is encoded, and i added a test to prevent this from happening again