### PR TITLE
chore(dexes): create dexes for existing users

### DIFF
--- a/db/migrations/20161020203012_backfill_dexes_table.js
+++ b/db/migrations/20161020203012_backfill_dexes_table.js
@@ -1,0 +1,21 @@
+'use strict';
+
+exports.up = function (knex, Promise) {
+  return knex('users').select('users.id').leftOuterJoin('dexes', 'users.id', 'dexes.user_id').whereNull('dexes.id')
+  .map((user) => {
+    return {
+      user_id: user.id,
+      title: 'Living Dex',
+      slug: 'living-dex',
+      shiny: false,
+      generation: 6,
+      date_created: new Date(),
+      date_modified: new Date()
+    };
+  })
+  .then((dexes) => knex('dexes').insert(dexes));
+};
+
+exports.down = function (knex, Promise) {
+  return knex('dexes').where('title', 'Living Dex').delete();
+};


### PR DESCRIPTION
Backfilling dexes for existing users. I decided to do it with one bulk `INSERT` call since [this SE answer](http://dba.stackexchange.com/questions/63055/increased-performance-from-single-statement-multiple-row-inserts) says it's more performant do to overhead on updating indices.