### PR TITLE
chore(captures): backfill dex_id for existing captures

### DIFF
--- a/db/migrations/20161020203012_backfill_dexes_table.js
+++ b/db/migrations/20161020203012_backfill_dexes_table.js
@@ -3,7 +3,11 @@
 const LIMIT = 1000;
 
 function batch (knex) {
-  return knex('users').select('users.id').leftOuterJoin('dexes', 'users.id', 'dexes.user_id').whereNull('dexes.id').limit(LIMIT)
+  return knex('users')
+    .select('users.id')
+    .leftOuterJoin('dexes', 'users.id', 'dexes.user_id')
+    .whereNull('dexes.id')
+    .limit(LIMIT)
   .map((user) => {
     return {
       user_id: user.id,
@@ -27,4 +31,8 @@ exports.up = function (knex, Promise) {
 
 exports.down = function (knex, Promise) {
   return knex('dexes').where('title', 'Living Dex').delete();
+};
+
+exports.config = {
+  transaction: false
 };

--- a/db/migrations/20161022233012_backfill_captures_dex_id.js
+++ b/db/migrations/20161022233012_backfill_captures_dex_id.js
@@ -1,0 +1,59 @@
+'use strict';
+
+const LIMIT = 10000;
+
+function upBatch (knex) {
+  return knex.raw(`
+    UPDATE captures
+    SET
+      dex_id = dexes.id
+    FROM users
+    INNER JOIN dexes ON users.id = dexes.user_id
+    WHERE
+      captures.user_id = users.id
+      AND (captures.pokemon_id, captures.user_id) IN (SELECT pokemon_id, user_id FROM captures WHERE dex_id IS NULL LIMIT ${LIMIT})
+  `)
+  .then((response) => {
+    return response.rowCount === LIMIT ? upBatch(knex) : null;
+  });
+}
+
+function downBatch (knex) {
+  return knex.raw(`
+    UPDATE captures
+    SET
+      dex_id = null
+    WHERE
+      (captures.pokemon_id, captures.user_id) IN (SELECT pokemon_id, user_id FROM captures WHERE dex_id IS NOT NULL LIMIT ${LIMIT})
+  `)
+  .then((response) => {
+    return response.rowCount === LIMIT ? downBatch(knex) : null;
+  });
+}
+
+exports.up = function (knex, Promise) {
+  return upBatch(knex)
+  .then(() => {
+    return knex.raw(`
+      BEGIN;
+      ALTER TABLE captures DROP CONSTRAINT captures_pkey;
+      ALTER TABLE captures ADD CONSTRAINT captures_pkey PRIMARY KEY (dex_id, pokemon_id);
+      COMMIT;
+    `);
+  });
+};
+
+exports.down = function (knex, Promise) {
+  return knex.raw(`
+    BEGIN;
+    ALTER TABLE captures DROP CONSTRAINT captures_pkey;
+    ALTER TABLE captures ADD CONSTRAINT captures_pkey PRIMARY KEY (user_id, pokemon_id);
+    ALTER TABLE captures ALTER COLUMN dex_id DROP NOT NULL;
+    COMMIT;
+  `)
+  .then(() => downBatch(knex));
+};
+
+exports.config = {
+  transaction: false
+};

--- a/test/plugins/features/captures/index.test.js
+++ b/test/plugins/features/captures/index.test.js
@@ -14,7 +14,7 @@ const user = Factory.build('user');
 
 const dex = Factory.build('dex', { user_id: user.id });
 
-const firstCapture = Factory.build('capture', { pokemon_id: firstPokemon.national_id, user_id: user.id });
+const firstCapture = Factory.build('capture', { pokemon_id: firstPokemon.national_id, user_id: user.id, dex_id: dex.id });
 
 const auth = `Bearer ${JWT.sign(user, Config.JWT_SECRET)}`;
 


### PR DESCRIPTION
- Backfill the `dex_id` of all existing `captures` by finding the only dex associated to the user.
- Do it in batches of 10,000 to preventing locking up of the DB (1,000 was a bit too slow).
- Change the primary key from `(user_id, pokemon_id)` to `(dex_id, pokemon_id)`, which also adds a `not null` constraint to `dex_id`.
- Modify the style of the previous backfill migration, so that it can be used as a good reference in the future.