### PR TITLE
feat(captures): allow filtering captures by dex and return dexes with users

### DIFF
--- a/src/libraries/jwt.js
+++ b/src/libraries/jwt.js
@@ -7,6 +7,6 @@ const Config = require('../../config');
 
 exports.sign = function (user) {
   return new Bluebird((resolve) => {
-    JWT.sign(user.serialize(), Config.JWT_SECRET, {}, (err, token) => resolve({ token }));
+    JWT.sign(user.get('jwt_summary'), Config.JWT_SECRET, {}, (err, token) => resolve({ token }));
   });
 };

--- a/src/models/capture.js
+++ b/src/models/capture.js
@@ -11,6 +11,7 @@ module.exports = Bookshelf.model('Capture', Bookshelf.Model.extend({
   },
   serialize () {
     return {
+      dex_id: this.get('dex_id'),
       user_id: this.get('user_id'),
       pokemon: this.related('pokemon').get('capture_summary'),
       captured: this.get('captured')

--- a/src/models/user.js
+++ b/src/models/user.js
@@ -5,13 +5,30 @@ const Bookshelf = require('../libraries/bookshelf');
 module.exports = Bookshelf.model('User', Bookshelf.Model.extend({
   tableName: 'users',
   hasTimestamps: ['date_created', 'date_modified'],
+  dexes () {
+    return this.hasMany('Dex');
+  },
+  virtuals: {
+    jwt_summary () {
+      return {
+        id: this.get('id'),
+        username: this.get('username'),
+        friend_code: this.get('friend_code'),
+        date_created: this.get('date_created'),
+        date_modified: this.get('date_modified')
+      };
+    }
+  },
   serialize () {
     return {
       id: this.get('id'),
       username: this.get('username'),
       friend_code: this.get('friend_code'),
+      dexes: this.related('dexes').map((dex) => dex.serialize()),
       date_created: this.get('date_created'),
       date_modified: this.get('date_modified')
     };
   }
+}, {
+  RELATED: [{ dexes: (qb) => qb.orderBy('date_created', 'DESC') }]
 }));

--- a/src/plugins/features/captures/controller.js
+++ b/src/plugins/features/captures/controller.js
@@ -10,11 +10,21 @@ const Pokemon = require('../../../models/pokemon');
 const User    = require('../../../models/user');
 
 exports.list = function (query, pokemon) {
-  return new User({ id: query.user }).fetch({ require: true })
-  .catch(User.NotFoundError, () => {
-    throw new Errors.NotFound('user');
+  return Bluebird.resolve()
+  .then(() => {
+    if (query.user) {
+      return new User({ id: query.user }).fetch({ require: true })
+      .catch(User.NotFoundError, () => {
+        throw new Errors.NotFound('user');
+      });
+    }
+
+    return new Dex({ id: query.dex }).fetch({ require: true })
+    .catch(Dex.NotFoundError, () => {
+      throw new Errors.NotFound('dex');
+    });
   })
-  .then(() => new Capture().where('user_id', query.user).fetchAll({ withRelated: Capture.RELATED }))
+  .then(() => new Capture().where(query.user ? 'user_id' : 'dex_id', query.user || query.dex).fetchAll({ withRelated: Capture.RELATED }))
   .get('models')
   .reduce((captures, capture) => {
     captures[capture.get('pokemon_id')] = capture;
@@ -28,7 +38,7 @@ exports.list = function (query, pokemon) {
         return captures[i + 1];
       }
 
-      const capture = Capture.forge({ user_id: query.user, pokemon_id: i + 1, captured: false });
+      const capture = Capture.forge({ dex_id: query.dex, user_id: query.user, pokemon_id: i + 1, captured: false });
       capture.relations.pokemon = pokemon[i];
       return capture;
     });

--- a/src/plugins/features/users/controller.js
+++ b/src/plugins/features/users/controller.js
@@ -17,11 +17,11 @@ exports.list = function (query) {
     qb.limit(query.limit);
     qb.offset(query.offset);
   })
-  .fetchAll();
+  .fetchAll({ withRelated: User.RELATED });
 };
 
 exports.retrieve = function (username) {
-  return new User().where('username', username).fetch({ require: true })
+  return new User().where('username', username).fetch({ require: true, withRelated: User.RELATED })
   .catch(User.NotFoundError, () => {
     throw new Errors.NotFound('user');
   });
@@ -56,7 +56,7 @@ exports.create = function (payload, request) {
       });
     });
   })
-  .then((user) => user.refresh())
+  .then((user) => user.refresh({ withRelated: User.RELATED }))
   .then((user) => JWT.sign(user))
   .catch(Errors.DuplicateKey, () => {
     throw new Errors.ExistingUsername();
@@ -72,7 +72,7 @@ exports.update = function (username, payload, auth) {
     }
   })
   .then(() => new User({ id: auth.id }).where('username', username).save(payload))
-  .then((user) => user.refresh())
+  .then((user) => user.refresh({ withRelated: User.RELATED }))
   .then((user) => JWT.sign(user))
   .catch(User.NoRowsUpdatedError, () => {
     throw new Errors.ForbiddenAction('updating this user');

--- a/src/validators/captures/list.js
+++ b/src/validators/captures/list.js
@@ -3,5 +3,7 @@
 const Joi = require('joi');
 
 module.exports = Joi.object({
-  user: Joi.number().integer().required()
-});
+  dex: Joi.number().integer(),
+  user: Joi.number().integer()
+})
+.xor(['dex', 'user']);

--- a/test/models/capture.test.js
+++ b/test/models/capture.test.js
@@ -18,6 +18,7 @@ describe('capture model', () => {
 
       expect(json).to.have.all.keys([
         'pokemon',
+        'dex_id',
         'user_id',
         'captured'
       ]);

--- a/test/models/user.test.js
+++ b/test/models/user.test.js
@@ -1,21 +1,48 @@
 'use strict';
 
+const Dex  = require('../../src/models/dex');
 const User = require('../../src/models/user');
 
 const user = Factory.build('user');
 
+const dex = Factory.build('dex', { user_id: user.id });
+
 describe('user model', () => {
+
+  describe('virtuals', () => {
+
+    describe('jwt_summary', () => {
+
+      it('only includes the fields needed for the JWT', () => {
+        expect(User.forge(user).get('jwt_summary')).to.have.all.keys([
+          'id',
+          'username',
+          'friend_code',
+          'date_created',
+          'date_modified'
+        ]);
+      });
+
+    });
+
+  });
 
   describe('serialize', () => {
 
     it('returns the correct fields', () => {
-      expect(User.forge(user).serialize()).to.have.all.keys([
+      const model = User.forge(user);
+      model.relations.dexes = [Dex.forge(dex), Dex.forge(dex)];
+      const json = model.serialize();
+
+      expect(json).to.have.all.keys([
         'id',
         'username',
         'friend_code',
+        'dexes',
         'date_created',
         'date_modified'
       ]);
+      expect(json.dexes).to.have.length(2);
     });
 
   });

--- a/test/plugins/features/captures/controller.test.js
+++ b/test/plugins/features/captures/controller.test.js
@@ -11,26 +11,29 @@ const Pokemon    = require('../../../../src/models/pokemon');
 const firstPokemon  = Factory.build('pokemon', { national_id: 1 });
 const secondPokemon = Factory.build('pokemon', { national_id: 2 });
 
-const user = Factory.build('user');
+const user      = Factory.build('user');
+const otherUser = Factory.build('user');
 
-const dex = Factory.build('dex', { user_id: user.id });
+const dex      = Factory.build('dex', { user_id: user.id });
+const otherDex = Factory.build('dex', { user_id: otherUser.id });
 
 const firstCapture = Factory.build('capture', { pokemon_id: firstPokemon.national_id, user_id: user.id, dex_id: dex.id });
+const otherCapture = Factory.build('capture', { pokemon_id: firstPokemon.national_id, user_id: otherUser.id, dex_id: otherDex.id });
 
 describe('capture controller', () => {
 
   beforeEach(() => {
     return Bluebird.all([
       Knex('pokemon').insert([firstPokemon, secondPokemon]),
-      Knex('users').insert(user)
+      Knex('users').insert([user, otherUser])
     ])
-    .then(() => Knex('dexes').insert(dex))
-    .then(() => Knex('captures').insert(firstCapture));
+    .then(() => Knex('dexes').insert([dex, otherDex]))
+    .then(() => Knex('captures').insert([firstCapture, otherCapture]));
   });
 
   describe('list', () => {
 
-    it('returns a collection of captures, filling in those that do not exist', () => {
+    it('returns a collection of captures filtered by user_id, filling in those that do not exist', () => {
       return new Pokemon().query((qb) => qb.orderBy('national_id')).fetchAll()
       .get('models')
       .then((pokemon) => Controller.list({ user: user.id }, pokemon))
@@ -46,9 +49,34 @@ describe('capture controller', () => {
       });
     });
 
+    it('returns a collection of captures filtered by dex_id, filling in those that do not exist', () => {
+      return new Pokemon().query((qb) => qb.orderBy('national_id')).fetchAll()
+      .get('models')
+      .then((pokemon) => Controller.list({ dex: dex.id }, pokemon))
+      .map((capture) => capture.serialize())
+      .then((captures) => {
+        expect(captures).to.have.length(2);
+        expect(captures[0].pokemon.national_id).to.eql(firstPokemon.national_id);
+        expect(captures[0].dex_id).to.eql(dex.id);
+        expect(captures[0].captured).to.be.true;
+        expect(captures[1].pokemon.national_id).to.eql(secondPokemon.national_id);
+        expect(captures[1].dex_id).to.eql(dex.id);
+        expect(captures[1].captured).to.be.false;
+      });
+    });
+
     it('rejects for a user id that does not exist', () => {
       return Controller.list({ user: -1 })
-      .catch((err) => err) .then((err) => {
+      .catch((err) => err)
+      .then((err) => {
+        expect(err).to.be.an.instanceof(Errors.NotFound);
+      });
+    });
+
+    it('rejects for a dex id that does not exist', () => {
+      return Controller.list({ dex: -1 })
+      .catch((err) => err)
+      .then((err) => {
         expect(err).to.be.an.instanceof(Errors.NotFound);
       });
     });
@@ -70,7 +98,8 @@ describe('capture controller', () => {
 
     it('rejects with a bad pokemon id', () => {
       return Controller.create({ pokemon: [-1] }, { id: user.id })
-      .catch((err) => err) .then((err) => {
+      .catch((err) => err)
+      .then((err) => {
         expect(err).to.be.an.instanceof(Errors.NotFound);
       });
     });

--- a/test/validators/captures/list.test.js
+++ b/test/validators/captures/list.test.js
@@ -6,15 +6,42 @@ const CapturesListValidator = require('../../../src/validators/captures/list');
 
 describe('captures list validator', () => {
 
-  describe('user', () => {
+  it('requires either dex or user', () => {
+    const data = {};
+    const result = Joi.validate(data, CapturesListValidator);
 
-    it('is required', () => {
-      const data = {};
+    expect(result.error.details[0].path).to.eql('value');
+    expect(result.error.details[0].type).to.eql('object.missing');
+  });
+
+  it('disallows both dex and user', () => {
+    const data = { dex: 1, user: 1 };
+    const result = Joi.validate(data, CapturesListValidator);
+
+    expect(result.error.details[0].path).to.eql('value');
+    expect(result.error.details[0].type).to.eql('object.xor');
+  });
+
+  describe('dex', () => {
+
+    it('allows integers', () => {
+      const data = { dex: 1 };
       const result = Joi.validate(data, CapturesListValidator);
 
-      expect(result.error.details[0].path).to.eql('user');
-      expect(result.error.details[0].type).to.eql('any.required');
+      expect(result.error).to.not.exist;
     });
+
+    it('disallows strings', () => {
+      const data = { dex: 'test' };
+      const result = Joi.validate(data, CapturesListValidator);
+
+      expect(result.error.details[0].path).to.eql('dex');
+      expect(result.error.details[0].type).to.eql('number.base');
+    });
+
+  });
+
+  describe('user', () => {
 
     it('allows integers', () => {
       const data = { user: 1 };


### PR DESCRIPTION
By allowing both `dex` and `user` filtering for this endpoint, we'll be able to migrate the front-end to use `dex` instead `user` without any downtime. Once the front-end isn't using using `user` anymore, then we'll get rid of that filter.

Also, this starts returning `dexes` with the user response. This is necessary so that we know the `dex_id` to use to filter the captures by. It also makes way for the profile page we'll be adding soon.