### PR TITLE
feat(users): allow passing in first dex params in user creation

### DIFF
--- a/src/models/dex.js
+++ b/src/models/dex.js
@@ -5,10 +5,6 @@ const Bookshelf = require('../libraries/bookshelf');
 module.exports = Bookshelf.model('Dex', Bookshelf.Model.extend({
   tableName: 'dexes',
   hasTimestamps: ['date_created', 'date_modified'],
-  defaults: {
-    shiny: false,
-    generation: 6
-  },
   serialize () {
     return {
       id: this.get('id'),

--- a/src/validators/users/create.js
+++ b/src/validators/users/create.js
@@ -6,7 +6,10 @@ module.exports = Joi.object().keys({
   username: Joi.string().token().max(20).trim().required(),
   password: Joi.string().min(8).max(72).required(),
   friend_code: Joi.string().regex(/^\d{4}-\d{4}-\d{4}$/).empty(['', null]),
-  referrer: Joi.string().empty(['', null])
+  referrer: Joi.string().empty(['', null]),
+  title: Joi.string().max(300).trim().default('Living Dex'),
+  shiny: Joi.boolean().default(false),
+  generation: Joi.number().integer().min(1).max(6).default(6)
 })
 .options({
   language: {

--- a/test/plugins/features/users/controller.test.js
+++ b/test/plugins/features/users/controller.test.js
@@ -80,12 +80,14 @@ describe('user controller', () => {
   describe('create', () => {
 
     const request = { headers: {}, info: {} };
+    const username = 'test';
+    const password = 'test';
+    const title = 'Living Dex';
+    const shiny = false;
+    const generation = 6;
 
     it('saves a user with a hashed password', () => {
-      const username = 'test';
-      const password = 'test';
-
-      return Controller.create({ username, password }, request)
+      return Controller.create({ username, password, title, shiny, generation }, request)
       .then(() => new User().where('username', username).fetch())
       .then((user) => {
         expect(user.get('password')).to.not.eql(password);
@@ -94,9 +96,7 @@ describe('user controller', () => {
     });
 
     it('returns a session with a user token', () => {
-      const username = 'test';
-
-      return Controller.create({ username, password: 'test' }, request)
+      return Controller.create({ username, password, title, shiny, generation }, request)
       .then((session) => {
         expect(session.token).to.be.a('string');
 
@@ -107,9 +107,7 @@ describe('user controller', () => {
     });
 
     it('saves last login date', () => {
-      const username = 'test';
-
-      return Controller.create({ username, password: 'test' }, request)
+      return Controller.create({ username, password, title, shiny, generation }, request)
       .then(() => new User().where('username', username).fetch())
       .then((user) => {
         expect(user.get('last_login')).to.be.an.instanceof(Date);
@@ -117,10 +115,9 @@ describe('user controller', () => {
     });
 
     it('saves referrer', () => {
-      const username = 'test';
       const referrer = 'http://test.com';
 
-      return Controller.create({ username, password: 'test', referrer }, request)
+      return Controller.create({ username, password, referrer, title, shiny, generation }, request)
       .then(() => new User().where('username', username).fetch())
       .then((user) => {
         expect(user.get('referrer')).to.eql(referrer);
@@ -128,9 +125,7 @@ describe('user controller', () => {
     });
 
     it('saves a default dex', () => {
-      const username = 'test';
-
-      return Controller.create({ username, password: 'test' }, request)
+      return Controller.create({ username, password, title, shiny, generation }, request)
       .then(() => new User().where('username', username).fetch())
       .then((user) => new Dex().where('user_id', user.id).fetch())
       .then((dex) => {
@@ -141,9 +136,7 @@ describe('user controller', () => {
 
     it('rejects if the username is already taken', () => {
       return Knex('users').insert(firstUser)
-      .then(() => {
-        return Controller.create({ username: firstUser.username, password: 'test' }, request);
-      })
+      .then(() => Controller.create({ username: firstUser.username, password, title, shiny, generation }, request))
       .catch((err) => err)
       .then((err) => {
         expect(err).to.be.an.instanceof(Errors.ExistingUsername);
@@ -153,7 +146,7 @@ describe('user controller', () => {
     it('rejects if the username is taken after the fetch', () => {
       Sinon.stub(User.prototype, 'save').throws(new Error('duplicate key value'));
 
-      return Controller.create({ username: firstUser.username, password: 'test' }, request)
+      return Controller.create({ username: firstUser.username, password, title, shiny, generation }, request)
       .catch((err) => err)
       .then((err) => {
         expect(err).to.be.an.instanceof(Errors.ExistingUsername);

--- a/test/validators/users/create.test.js
+++ b/test/validators/users/create.test.js
@@ -8,6 +8,14 @@ describe('users create validator', () => {
 
   describe('username', () => {
 
+    it('is required', () => {
+      const data = { password: 'testtest' };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error.details[0].path).to.eql('username');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
     it('allows alpha-numeric and underscore characters', () => {
       const data = { username: 'test_TEST', password: 'testtest' };
       const result = Joi.validate(data, UsersCreateValidator);
@@ -43,6 +51,14 @@ describe('users create validator', () => {
 
   describe('password', () => {
 
+    it('is required', () => {
+      const data = { username: 'testing' };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error.details[0].path).to.eql('password');
+      expect(result.error.details[0].type).to.eql('any.required');
+    });
+
     it('requires at least 8 characters', () => {
       const data = { username: 'testing', password: 'a'.repeat(7) };
       const result = Joi.validate(data, UsersCreateValidator);
@@ -62,6 +78,13 @@ describe('users create validator', () => {
   });
 
   describe('friend_code', () => {
+
+    it('is optional', () => {
+      const data = { username: 'testing', password: 'testtest' };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
 
     it('converts null to undefined', () => {
       const data = { username: 'testing', password: 'testtest', friend_code: null };
@@ -124,6 +147,77 @@ describe('users create validator', () => {
       const result = Joi.validate(data, UsersCreateValidator);
 
       expect(result.value.referrer).to.be.undefined;
+    });
+
+  });
+
+  describe('title', () => {
+
+    it('defaults to "Living Dex"', () => {
+      const data = { username: 'testing', password: 'testtest' };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value.title).to.eql('Living Dex');
+    });
+
+    it('limits to 300 characters', () => {
+      const data = { username: 'testing', password: 'testtest', title: 'a'.repeat(301) };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error.details[0].path).to.eql('title');
+      expect(result.error.details[0].type).to.eql('string.max');
+    });
+
+  });
+
+  describe('shiny', () => {
+
+    it('defaults to false', () => {
+      const data = { username: 'testing', password: 'testtest' };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value.shiny).to.be.false;
+    });
+
+  });
+
+  describe('generation', () => {
+
+    it('defaults to 6', () => {
+      const data = { username: 'testing', password: 'testtest' };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.value.generation).to.eql(6);
+    });
+
+    it('allows at least 1', () => {
+      const data = { username: 'testing', password: 'testtest', generation: 1 };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('allows at most 6', () => {
+      const data = { username: 'testing', password: 'testtest', generation: 6 };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('disallows less than 1', () => {
+      const data = { username: 'testing', password: 'testtest', generation: 0 };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error.details[0].path).to.eql('generation');
+      expect(result.error.details[0].type).to.eql('number.min');
+    });
+
+    it('disallows more than 6', () => {
+      const data = { username: 'testing', password: 'testtest', generation: 7 };
+      const result = Joi.validate(data, UsersCreateValidator);
+
+      expect(result.error.details[0].path).to.eql('generation');
+      expect(result.error.details[0].type).to.eql('number.max');
     });
 
   });


### PR DESCRIPTION
These changes will allow us to pass in custom params for the user's first dex when we add these fields to the signup page. But for now, it'll just use the defaults (`{ title: 'Living Dex', shiny: false, generation: 6 }`).