### PR TITLE
chore(captures): allow dex param for create and delete

### DIFF
--- a/src/validators/captures/create.js
+++ b/src/validators/captures/create.js
@@ -3,5 +3,6 @@
 const Joi = require('joi');
 
 module.exports = Joi.object({
+  dex: Joi.number().integer(),
   pokemon: Joi.array().items(Joi.number().integer()).single().required()
 });

--- a/src/validators/captures/delete.js
+++ b/src/validators/captures/delete.js
@@ -3,5 +3,6 @@
 const Joi = require('joi');
 
 module.exports = Joi.object({
+  dex: Joi.number().integer(),
   pokemon: Joi.array().items(Joi.number().integer()).single().required()
 });

--- a/test/validators/captures/create.test.js
+++ b/test/validators/captures/create.test.js
@@ -6,10 +6,28 @@ const CapturesCreateValidator = require('../../../src/validators/captures/create
 
 describe('captures create validator', () => {
 
+  describe('dex', () => {
+
+    it('is optional', () => {
+      const data = { pokemon: [1] };
+      const result = Joi.validate(data, CapturesCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('allows integers', () => {
+      const data = { dex: 1, pokemon: [1] };
+      const result = Joi.validate(data, CapturesCreateValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+  });
+
   describe('pokemon', () => {
 
     it('is required', () => {
-      const data = {};
+      const data = { dex: 1 };
       const result = Joi.validate(data, CapturesCreateValidator);
 
       expect(result.error.details[0].path).to.eql('pokemon');
@@ -17,7 +35,7 @@ describe('captures create validator', () => {
     });
 
     it('allows an array of integers', () => {
-      const data = { pokemon: [1] };
+      const data = { dex: 1, pokemon: [1] };
       const result = Joi.validate(data, CapturesCreateValidator);
 
       expect(result.error).to.not.exist;
@@ -25,7 +43,7 @@ describe('captures create validator', () => {
     });
 
     it('allows a single integer', () => {
-      const data = { pokemon: 1 };
+      const data = { dex: 1, pokemon: 1 };
       const result = Joi.validate(data, CapturesCreateValidator);
 
       expect(result.error).to.not.exist;
@@ -33,7 +51,7 @@ describe('captures create validator', () => {
     });
 
     it('disallows an array of strings', () => {
-      const data = { pokemon: ['test'] };
+      const data = { dex: 1, pokemon: ['test'] };
       const result = Joi.validate(data, CapturesCreateValidator);
 
       expect(result.error.details[0].path).to.eql('pokemon.0');

--- a/test/validators/captures/delete.test.js
+++ b/test/validators/captures/delete.test.js
@@ -6,6 +6,24 @@ const CapturesDeleteValidator = require('../../../src/validators/captures/delete
 
 describe('captures delete validator', () => {
 
+  describe('dex', () => {
+
+    it('is optional', () => {
+      const data = { pokemon: [1] };
+      const result = Joi.validate(data, CapturesDeleteValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+    it('allows integers', () => {
+      const data = { dex: 1, pokemon: [1] };
+      const result = Joi.validate(data, CapturesDeleteValidator);
+
+      expect(result.error).to.not.exist;
+    });
+
+  });
+
   describe('pokemon', () => {
 
     it('is required', () => {


### PR DESCRIPTION
allow `dex` so that we can at least start passing it in, even though its not being used yet. after weve deployed the front-end that passes `dex`, we can then start using it. this will make for a zero-downtime change.