### PR TITLE
feat(captures): use the dex id that's passed in

### DIFF
--- a/src/validators/captures/create.js
+++ b/src/validators/captures/create.js
@@ -3,6 +3,6 @@
 const Joi = require('joi');
 
 module.exports = Joi.object({
-  dex: Joi.number().integer(),
+  dex: Joi.number().integer().required(),
   pokemon: Joi.array().items(Joi.number().integer()).single().required()
 });

--- a/src/validators/captures/delete.js
+++ b/src/validators/captures/delete.js
@@ -3,6 +3,6 @@
 const Joi = require('joi');
 
 module.exports = Joi.object({
-  dex: Joi.number().integer(),
+  dex: Joi.number().integer().required(),
   pokemon: Joi.array().items(Joi.number().integer()).single().required()
 });

--- a/test/plugins/features/captures/index.test.js
+++ b/test/plugins/features/captures/index.test.js
@@ -51,7 +51,7 @@ describe('captures integration', () => {
         method: 'POST',
         url: '/captures',
         headers: { authorization: auth },
-        payload: { pokemon: secondPokemon.national_id }
+        payload: { pokemon: secondPokemon.national_id, dex: dex.id }
       })
       .then((res) => {
         expect(res.statusCode).to.eql(200);
@@ -63,7 +63,7 @@ describe('captures integration', () => {
       return Server.inject({
         method: 'POST',
         url: '/captures',
-        payload: { pokemon: secondPokemon.national_id }
+        payload: { pokemon: secondPokemon.national_id, dex: dex.id }
       })
       .then((res) => {
         expect(res.statusCode).to.eql(401);
@@ -79,7 +79,7 @@ describe('captures integration', () => {
         method: 'DELETE',
         url: '/captures',
         headers: { authorization: auth },
-        payload: { pokemon: firstPokemon.national_id }
+        payload: { pokemon: firstPokemon.national_id, dex: dex.id }
       })
       .then((res) => {
         expect(res.statusCode).to.eql(200);
@@ -91,7 +91,7 @@ describe('captures integration', () => {
       return Server.inject({
         method: 'DELETE',
         url: '/captures',
-        payload: { pokemon: firstPokemon.national_id }
+        payload: { pokemon: firstPokemon.national_id, dex: dex.id }
       })
       .then((res) => {
         expect(res.statusCode).to.eql(401);

--- a/test/validators/captures/create.test.js
+++ b/test/validators/captures/create.test.js
@@ -8,11 +8,12 @@ describe('captures create validator', () => {
 
   describe('dex', () => {
 
-    it('is optional', () => {
+    it('is required', () => {
       const data = { pokemon: [1] };
       const result = Joi.validate(data, CapturesCreateValidator);
 
-      expect(result.error).to.not.exist;
+      expect(result.error.details[0].path).to.eql('dex');
+      expect(result.error.details[0].type).to.eql('any.required');
     });
 
     it('allows integers', () => {

--- a/test/validators/captures/delete.test.js
+++ b/test/validators/captures/delete.test.js
@@ -8,11 +8,12 @@ describe('captures delete validator', () => {
 
   describe('dex', () => {
 
-    it('is optional', () => {
+    it('is required', () => {
       const data = { pokemon: [1] };
       const result = Joi.validate(data, CapturesDeleteValidator);
 
-      expect(result.error).to.not.exist;
+      expect(result.error.details[0].path).to.eql('dex');
+      expect(result.error.details[0].type).to.eql('any.required');
     });
 
     it('allows integers', () => {
@@ -27,7 +28,7 @@ describe('captures delete validator', () => {
   describe('pokemon', () => {
 
     it('is required', () => {
-      const data = {};
+      const data = { dex: 1 };
       const result = Joi.validate(data, CapturesDeleteValidator);
 
       expect(result.error.details[0].path).to.eql('pokemon');
@@ -35,7 +36,7 @@ describe('captures delete validator', () => {
     });
 
     it('allows an array of integers', () => {
-      const data = { pokemon: [1] };
+      const data = { dex: 1, pokemon: [1] };
       const result = Joi.validate(data, CapturesDeleteValidator);
 
       expect(result.error).to.not.exist;
@@ -43,7 +44,7 @@ describe('captures delete validator', () => {
     });
 
     it('allows a single integer', () => {
-      const data = { pokemon: 1 };
+      const data = { dex: 1, pokemon: 1 };
       const result = Joi.validate(data, CapturesDeleteValidator);
 
       expect(result.error).to.not.exist;
@@ -51,7 +52,7 @@ describe('captures delete validator', () => {
     });
 
     it('disallows an array of strings', () => {
-      const data = { pokemon: ['test'] };
+      const data = { dex: 1, pokemon: ['test'] };
       const result = Joi.validate(data, CapturesDeleteValidator);
 
       expect(result.error.details[0].path).to.eql('pokemon.0');


### PR DESCRIPTION
now that https://github.com/robinjoseph08/pokedextracker.com/pull/204 has been deployed and we're passing in the associated dex id to the capture endpoints, we can now use these ids. it should be the exact functionality as it was before (where it used the only dex that exists on the user), but now it allows us to start marking captures for other dexes for the user.