### PR TITLE
chore(pokemon): remove unused columns

### DIFF
--- a/db/migrations/20161119185041_drop_unnecessary_columns_on_pokemon.js
+++ b/db/migrations/20161119185041_drop_unnecessary_columns_on_pokemon.js
@@ -1,0 +1,60 @@
+'use strict';
+
+const TYPES = [
+  'normal',
+  'fighting',
+  'flying',
+  'poison',
+  'ground',
+  'rock',
+  'bug',
+  'ghost',
+  'steel',
+  'fire',
+  'water',
+  'grass',
+  'electric',
+  'psychic',
+  'ice',
+  'dragon',
+  'dark',
+  'fairy'
+];
+
+exports.up = function (knex, Promise) {
+  return knex.schema.table('pokemon', (table) => {
+    table.dropColumn('regionless');
+    table.dropColumn('type1');
+    table.dropColumn('type2');
+    table.dropColumn('icon_url');
+    table.dropColumn('avatar_url');
+  })
+  .then(() => {
+    return knex.raw(`
+      ALTER TABLE pokemon
+        ALTER COLUMN x_location DROP NOT NULL,
+        ALTER COLUMN y_location DROP NOT NULL,
+        ALTER COLUMN or_location DROP NOT NULL,
+        ALTER COLUMN as_location DROP NOT NULL
+    `);
+  });
+};
+
+exports.down = function (knex, Promise) {
+  return knex.schema.table('pokemon', (table) => {
+    table.boolean('regionless').notNullable().defaultTo(false);
+    table.enum('type1', TYPES).notNullable();
+    table.enum('type2', TYPES);
+    table.string('icon_url').notNullable();
+    table.string('avatar_url').notNullable();
+  })
+  .then(() => {
+    return knex.raw(`
+      ALTER TABLE pokemon
+        ALTER COLUMN x_location SET NOT NULL,
+        ALTER COLUMN y_location SET NOT NULL,
+        ALTER COLUMN or_location SET NOT NULL,
+        ALTER COLUMN as_location SET NOT NULL
+    `);
+  });
+};

--- a/src/models/pokemon.js
+++ b/src/models/pokemon.js
@@ -33,8 +33,7 @@ module.exports = Bookshelf.model('Pokemon', Bookshelf.Model.extend({
         unova_id: this.get('unova_id') || undefined,
         central_kalos_id: this.get('central_kalos_id') || undefined,
         coastal_kalos_id: this.get('coastal_kalos_id') || undefined,
-        mountain_kalos_id: this.get('mountain_kalos_id') || undefined,
-        regionless: this.get('regionless') || undefined
+        mountain_kalos_id: this.get('mountain_kalos_id') || undefined
       };
     },
     serebii_url () {
@@ -46,20 +45,17 @@ module.exports = Bookshelf.model('Pokemon', Bookshelf.Model.extend({
         name: this.get('name')
       };
     },
-    types () {
-      return [this.get('type1'), this.get('type2')].filter((type) => type);
-    },
     x_locations () {
-      return this.get('x_location').split(', ');
+      return this.get('x_location') ? this.get('x_location').split(', ') : [];
     },
     y_locations () {
-      return this.get('y_location').split(', ');
+      return this.get('y_location') ? this.get('y_location').split(', ') : [];
     },
     or_locations () {
-      return this.get('or_location').split(', ');
+      return this.get('or_location') ? this.get('or_location').split(', ') : [];
     },
     as_locations () {
-      return this.get('as_location').split(', ');
+      return this.get('as_location') ? this.get('as_location').split(', ') : [];
     }
   },
   serialize () {
@@ -110,7 +106,6 @@ module.exports = Bookshelf.model('Pokemon', Bookshelf.Model.extend({
         central_kalos_id: this.get('central_kalos_id') || undefined,
         coastal_kalos_id: this.get('coastal_kalos_id') || undefined,
         mountain_kalos_id: this.get('mountain_kalos_id') || undefined,
-        regionless: this.get('regionless') || undefined,
         bulbapedia_url: this.get('bulbapedia_url'),
         serebii_url: this.get('serebii_url'),
         x_locations: this.get('x_locations'),

--- a/test/factories/pokemon.js
+++ b/test/factories/pokemon.js
@@ -4,11 +4,4 @@ module.exports = Factory.define('pokemon')
   .sequence('national_id')
   .sequence('evolution_family_id')
   .attr('name', '')
-  .attr('type1', 'fire')
-  .attr('icon_url', '')
-  .attr('avatar_url', '')
-  .attr('generation', 1)
-  .attr('x_location', '')
-  .attr('y_location', '')
-  .attr('or_location', '')
-  .attr('as_location', '');
+  .attr('generation', 1);

--- a/test/models/capture.test.js
+++ b/test/models/capture.test.js
@@ -32,8 +32,7 @@ describe('capture model', () => {
         'unova_id',
         'central_kalos_id',
         'coastal_kalos_id',
-        'mountain_kalos_id',
-        'regionless'
+        'mountain_kalos_id'
       ]);
     });
 

--- a/test/models/pokemon.test.js
+++ b/test/models/pokemon.test.js
@@ -56,8 +56,7 @@ describe('pokemon model', () => {
           'unova_id',
           'central_kalos_id',
           'coastal_kalos_id',
-          'mountain_kalos_id',
-          'regionless'
+          'mountain_kalos_id'
         ]);
       });
 
@@ -90,22 +89,14 @@ describe('pokemon model', () => {
 
     });
 
-    describe('types', () => {
-
-      it('returns an array of types', () => {
-        expect(Pokemon.forge({ type1: 'fire', type2: 'water' }).get('types')).to.eql(['fire', 'water']);
-      });
-
-      it('doesn\'t include the second type if it does exist', () => {
-        expect(Pokemon.forge({ type1: 'fire' }).get('types')).to.eql(['fire']);
-      });
-
-    });
-
     describe('x_locations', () => {
 
       it('splits by commas', () => {
         expect(Pokemon.forge({ x_location: 'Route 1, Route 2' }).get('x_locations')).to.eql(['Route 1', 'Route 2']);
+      });
+
+      it('returns an empty array if the value does not exist', () => {
+        expect(Pokemon.forge({ x_location: null }).get('x_locations')).to.eql([]);
       });
 
     });
@@ -116,6 +107,10 @@ describe('pokemon model', () => {
         expect(Pokemon.forge({ y_location: 'Route 1, Route 2' }).get('y_locations')).to.eql(['Route 1', 'Route 2']);
       });
 
+      it('returns an empty array if the value does not exist', () => {
+        expect(Pokemon.forge({ y_location: null }).get('y_locations')).to.eql([]);
+      });
+
     });
 
     describe('or_locations', () => {
@@ -124,12 +119,20 @@ describe('pokemon model', () => {
         expect(Pokemon.forge({ or_location: 'Route 1, Route 2' }).get('or_locations')).to.eql(['Route 1', 'Route 2']);
       });
 
+      it('returns an empty array if the value does not exist', () => {
+        expect(Pokemon.forge({ or_location: null }).get('or_locations')).to.eql([]);
+      });
+
     });
 
     describe('as_locations', () => {
 
       it('splits by commas', () => {
         expect(Pokemon.forge({ as_location: 'Route 1, Route 2' }).get('as_locations')).to.eql(['Route 1', 'Route 2']);
+      });
+
+      it('returns an empty array if the value does not exist', () => {
+        expect(Pokemon.forge({ as_location: null }).get('as_locations')).to.eql([]);
       });
 
     });
@@ -152,7 +155,6 @@ describe('pokemon model', () => {
           'central_kalos_id',
           'coastal_kalos_id',
           'mountain_kalos_id',
-          'regionless',
           'bulbapedia_url',
           'serebii_url',
           'x_locations',


### PR DESCRIPTION
We don't use several of these columns and as we're looking to add more pokemon for gen VII, we don't need to be scraping this additional info. I also made the gen VI locations nullable since the new gen VII pokemon won't have those locations.